### PR TITLE
Added a check for buildResult Format 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 hs_err_pid*
 
 /target
+/work
+.vscode*

--- a/src/main/java/com/telerik/plugins/appbuilderci/TelerikAppBuilder.java
+++ b/src/main/java/com/telerik/plugins/appbuilderci/TelerikAppBuilder.java
@@ -248,6 +248,9 @@ public class TelerikAppBuilder extends Builder {
 		for(Object obj : buildResultItems)
 		{
 			JSONObject item = (JSONObject) obj;
+                        if (!"LocalPath".equals(item.getString("Format"))) {
+                            break;
+                        }
 			String itemUrl = item.getString("FullPath");
 			String extension = item.getString("Extension");
 			String pathFormat = item.getString("Format");

--- a/src/main/java/com/telerik/plugins/appbuilderci/TelerikAppBuilder.java
+++ b/src/main/java/com/telerik/plugins/appbuilderci/TelerikAppBuilder.java
@@ -248,9 +248,9 @@ public class TelerikAppBuilder extends Builder {
 		for(Object obj : buildResultItems)
 		{
 			JSONObject item = (JSONObject) obj;
-                        if (!"LocalPath".equals(item.getString("Format"))) {
-                            break;
-                        }
+			if (!"LocalPath".equals(item.getString("Format"))) {
+				continue;
+			}
 			String itemUrl = item.getString("FullPath");
 			String extension = item.getString("Extension");
 			String pathFormat = item.getString("Format");


### PR DESCRIPTION
Added a check for buildResult Format to ignore result items that are …not downloadable files. Was causing an exception when trying to download build metadata. Perhaps the buildResult JSON object was changed by Telerik? It now returns a third item with app package metadata. It's not a downloadble artifact and was causing a build failure. 